### PR TITLE
Fix board screen

### DIFF
--- a/App.js
+++ b/App.js
@@ -74,14 +74,14 @@ export default function App() {
   function boardsScreen({ navigation }) {
     return (
       <>
-        <View style={{ alignItems: 'center', top: 12 }}>
+        <View style={{ alignItems: 'center', position: 'relative' }}>
           <View style={styles.boardContainer}>
             <View style={styles.screenTitleView}>
               <Text style={styles.screenTitleText}>{boardsType} boards</Text>
             </View>
           </View>
           <Board boardType={boardsType} navigator={navigation} />
-          <Board boardType={boardsType} navigator={navigation} v />
+          <Board boardType={boardsType} navigator={navigation} />
           <Board boardType={boardsType} navigator={navigation} />
           <UserBar
             userPhoto={{ uri: userPhoto }}
@@ -135,7 +135,7 @@ const styles = StyleSheet.create({
     marginBottom: 5,
   },
   boardContainer: {
-    marginTop: 75,
+    marginTop: 95,
     width: '90%',
     alignSelf: 'center'
   },

--- a/components/board.jsx
+++ b/components/board.jsx
@@ -35,12 +35,12 @@ const Board = (props) => {
 const styles = StyleSheet.create({
     boardView: {
         width: '91%',
+        position: 'relative',
         height: 180,
         marginBottom: 20,
         backgroundColor: 'lightgray',
         flexDirection: 'row',
         justifyContent: 'space-between',
-        elevation: 20,
     },
     boardText: {
         flexDirection: 'column',

--- a/components/board.jsx
+++ b/components/board.jsx
@@ -41,6 +41,7 @@ const styles = StyleSheet.create({
         backgroundColor: 'lightgray',
         flexDirection: 'row',
         justifyContent: 'space-between',
+        elevation: 20,
     },
     boardText: {
         flexDirection: 'column',

--- a/components/userBar.jsx
+++ b/components/userBar.jsx
@@ -248,7 +248,7 @@ const styles = StyleSheet.create({
   searchMenuBoards: {
     position: 'absolute',
     right: '20%',
-    top: 75,
+    top: 98,
     width: 150,
     height: 100,
     backgroundColor: '#c4c4c4',

--- a/components/userBar.jsx
+++ b/components/userBar.jsx
@@ -234,6 +234,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#F9D01E',
     alignItems: 'center',
     marginTop: 20,
+    elevation: 21,
   },
   searchMenu: {
     position: 'absolute',
@@ -244,6 +245,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#F9D01E',
     alignItems: 'center',
     marginTop: 20,
+    elevation: 21,
   },
   searchMenuBoards: {
     position: 'absolute',
@@ -253,6 +255,7 @@ const styles = StyleSheet.create({
     height: 100,
     backgroundColor: '#c4c4c4',
     alignItems: 'center',
+    elevation: 21,
   },
   optionsMenu: {
     position: 'absolute',
@@ -263,6 +266,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#F9D01E',
     alignItems: 'center',
     marginTop: 20,
+    elevation: 21,
   },
   menuButton: {
     borderColor: '#201E3C',


### PR DESCRIPTION
Turns out, the menu was wonky because I added the CSS property "Elevation: 20" to the board elements, and this makes the boards go on top of the menu for some reason. I thought it only added a shadow, but apparently it changes more. So now the menus have "Elevation: 21", and it turns out, it looks pretty clean (in my opinion), so yay!