### PR TITLE
Filter instead of search

### DIFF
--- a/components/userBar.jsx
+++ b/components/userBar.jsx
@@ -120,7 +120,7 @@ const UserBar = (props) => {
         searchType === 'creator' && !props.boardScreen) {
       setSearchType('pin');
     }
-    return 'Search for ' + searchType + '...';
+    return 'Filter by ' + searchType + '...';
   }
 
   return (


### PR DESCRIPTION
Very small change - just making the UserBar say "Filter by" instead of "search for," because we are technically filtering rather than searching